### PR TITLE
Fix: Configure Vercel deployment for Vite application

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,9 @@
-
 {
   "version": 2,
   "builds": [
     {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
+      "src": "vercel-build.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [


### PR DESCRIPTION
Previously, vercel.json was configured with @vercel/static-build, which is not suitable for your Vite/React application.

This change updates vercel.json to use @vercel/node and a custom build script (vercel-build.js). This ensures that the correct build commands (`npm install` and `npm run build`) are executed in the Vercel environment, and the resulting `dist` directory is served.

This should resolve the deployment failures on Vercel.